### PR TITLE
Fix "rosdep" command not found error

### DIFF
--- a/ros-melodic-desktop.sh
+++ b/ros-melodic-desktop.sh
@@ -10,7 +10,7 @@ sudo apt install -y curl
 curl -k https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo apt-key add -
 sudo apt update || echo ""
 
-sudo apt install -y ros-${ROS_DISTRO}-desktop-full
+sudo apt install -y ros-${ROS_DISTRO}-desktop-full python-rosdep
 
 ls /etc/ros/rosdep/sources.list.d/20-default.list && sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 sudo rosdep init 

--- a/ros-melodic-ros-base.sh
+++ b/ros-melodic-ros-base.sh
@@ -10,7 +10,7 @@ sudo apt install -y curl
 curl -k https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo apt-key add -
 sudo apt update || echo ""
 
-sudo apt install -y ros-${ROS_DISTRO}-ros-base
+sudo apt install -y ros-${ROS_DISTRO}-ros-base python-rosdep
 
 ls /etc/ros/rosdep/sources.list.d/20-default.list && sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 sudo rosdep init 


### PR DESCRIPTION
This is an hot-fix for #1.
This fix is maybe not a permanent fix.