### PR TITLE
feat: Execute only with Python 2

### DIFF
--- a/ros-kinetic-desktop.sh
+++ b/ros-kinetic-desktop.sh
@@ -11,6 +11,7 @@ curl -k https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo ap
 sudo apt update || echo ""
 
 sudo apt install -y ros-${ROS_DISTRO}-desktop-full
+python --version 2>&1 | grep -q "2.7" || exit 1
 
 ls /etc/ros/rosdep/sources.list.d/20-default.list && sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 sudo rosdep init 

--- a/ros-kinetic-ros-base.sh
+++ b/ros-kinetic-ros-base.sh
@@ -11,6 +11,7 @@ curl -k https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo ap
 sudo apt update || echo ""
 
 sudo apt install -y ros-${ROS_DISTRO}-ros-base
+python --version 2>&1 | grep -q "2.7" || exit 1
 
 ls /etc/ros/rosdep/sources.list.d/20-default.list && sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 sudo rosdep init 

--- a/ros-melodic-desktop.sh
+++ b/ros-melodic-desktop.sh
@@ -11,6 +11,7 @@ curl -k https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo ap
 sudo apt update || echo ""
 
 sudo apt install -y ros-${ROS_DISTRO}-desktop-full python-rosdep
+python --version 2>&1 | grep -q "2.7" || exit 1
 
 ls /etc/ros/rosdep/sources.list.d/20-default.list && sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 sudo rosdep init 

--- a/ros-melodic-ros-base.sh
+++ b/ros-melodic-ros-base.sh
@@ -11,6 +11,7 @@ curl -k https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo ap
 sudo apt update || echo ""
 
 sudo apt install -y ros-${ROS_DISTRO}-ros-base python-rosdep
+python --version 2>&1 | grep -q "2.7" || exit 1
 
 ls /etc/ros/rosdep/sources.list.d/20-default.list && sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
 sudo rosdep init 


### PR DESCRIPTION
Python 2 is EOL, but ROS Kinetic and Melodic only supports Python 2